### PR TITLE
obey config.assets.prefix. Closes ## 1 and 2

### DIFF
--- a/lib/guard/rails-assets.rb
+++ b/lib/guard/rails-assets.rb
@@ -26,12 +26,9 @@ module Guard
 
     def compile_assets
       puts 'Compiling rails assets'
-      result = system "rm -rf public/assets && bundle exec rake assets:precompile"   
+      result = system "bundle exec rake assets:clean assets:precompile"
       if result
-        tree = `tree public/assets`
-        puts tree
-        summary = tree.split("\n").last
-        Notifier::notify summary, :title => 'Assets compiled'
+        Notifier::notify 'Assets compiled'
       else
         Notifier::notify 'see the details in the terminal', :title => "Can't compile assets", :image => :failed
       end

--- a/spec/guard/rails-assets_spec.rb
+++ b/spec/guard/rails-assets_spec.rb
@@ -28,13 +28,12 @@ describe Guard::RailsAssets do
 
   describe 'asset compilation using CLI' do
     def stub_system_with result
-      subject.should_receive(:system).with("rm -rf public/assets && bundle exec rake assets:precompile").and_return result
+      subject.should_receive(:system).with("bundle exec rake assets:clean assets:precompile").and_return result
     end
 
     it 'should notify on success' do
       stub_system_with true
-      subject.should_receive(:`).with('tree public/assets').and_return "a\nb\n1 directory, 2 files"
-      Guard::Notifier.should_receive(:notify).with('1 directory, 2 files', :title => 'Assets compiled')
+      Guard::Notifier.should_receive(:notify).with('Assets compiled')
       subject.compile_assets
     end
     it 'should notify on failure' do
@@ -43,9 +42,5 @@ describe Guard::RailsAssets do
       Guard::Notifier.should_receive(:notify).with('see the details in the terminal', :title => "Can't compile assets", :image => :failed)
       subject.compile_assets
     end
-  end
-
-  describe 'custom assets prefix' do
-    it 'should use given prefix'
   end
 end


### PR DESCRIPTION
This approach does the following
- use `rake assets:clean` to do the cleanup instead of `rm -rf public/assets`, thus letting Rails figure out the right directory. Rails currently doesn't clean out image files, though that may be fixed in the future
- don't bother with trying `tree public/assets` to get more information; just assume that "Assets generated" is enough information

This is mutually exclusive with https://github.com/guard/guard-rails-assets/pull/2
