### PR TITLE
add :assets_prefix configuration; tree is optional. Closes ## 1 and 2

### DIFF
--- a/lib/guard/rails-assets.rb
+++ b/lib/guard/rails-assets.rb
@@ -29,10 +29,7 @@ module Guard
       puts 'Compiling rails assets'
       result = system "rm -rf #{assets_dir} && bundle exec rake assets:precompile"
       if result
-        tree = `tree #{assets_dir}`
-        puts tree
-        summary = tree.split("\n").last
-        Notifier::notify summary, :title => 'Assets compiled'
+        Notifier::notify success_summary, :title => 'Assets compiled'
       else
         Notifier::notify 'see the details in the terminal', :title => "Can't compile assets", :image => :failed
       end
@@ -49,6 +46,21 @@ module Guard
       run_on = [:start, :all, :change] if not run_on or run_on.empty? 
       run_on = [run_on] unless run_on.respond_to?(:include?)
       run_on.include?(command)
+    end
+
+    def success_summary
+      if system_has_tree?
+        tree = `tree #{assets_dir}`
+        puts tree
+        tree.split("\n").last
+      else
+        '(Install tree for additional information)'
+      end
+    end
+
+    def system_has_tree?
+      return @has_tree if instance_variable_defined?(:@has_tree)
+      @has_tree = system "which tree"
     end
   end
 end

--- a/spec/guard/rails-assets_spec.rb
+++ b/spec/guard/rails-assets_spec.rb
@@ -25,20 +25,23 @@ describe Guard::RailsAssets do
     it_behaves_like 'guard command', :command => :run_on_change, :run => true
   end
 
+  def stub_system_with dir, result
+    subject.should_receive(:system).with("rm -rf #{dir} && bundle exec rake assets:precompile").and_return result
+  end
 
   describe 'asset compilation using CLI' do
-    def stub_system_with result
-      subject.should_receive(:system).with("rm -rf public/assets && bundle exec rake assets:precompile").and_return result
+    before(:each) do
+      subject.stub(:system_has_tree?) { true }
     end
 
     it 'should notify on success' do
-      stub_system_with true
+      stub_system_with 'public/assets', true
       subject.should_receive(:`).with('tree public/assets').and_return "a\nb\n1 directory, 2 files"
       Guard::Notifier.should_receive(:notify).with('1 directory, 2 files', :title => 'Assets compiled')
       subject.compile_assets
     end
     it 'should notify on failure' do
-      stub_system_with false
+      stub_system_with 'public/assets', false
       subject.should_not_receive(:`) # don't obtain tree
       Guard::Notifier.should_receive(:notify).with('see the details in the terminal', :title => "Can't compile assets", :image => :failed)
       subject.compile_assets
@@ -48,12 +51,26 @@ describe Guard::RailsAssets do
   describe 'custom assets prefix' do
     before(:each) do
       options[:assets_prefix] = 'my/assets'
+      subject.stub(:system_has_tree?) { true }
     end
 
     it 'should use given prefix for cleanup and compilation' do
-      subject.should_receive(:system).with("rm -rf public/my/assets && bundle exec rake assets:precompile").and_return true
+      stub_system_with 'public/my/assets', true
       subject.should_receive(:`).with('tree public/my/assets').and_return "a\nb\n1 directory, 2 files"
       Guard::Notifier.should_receive(:notify).with('1 directory, 2 files', :title => 'Assets compiled')
+      subject.compile_assets
+    end
+  end
+
+  describe 'a system without the tree command' do
+    before(:each) do
+      subject.should_receive(:system_has_tree?).and_return false
+    end
+
+    it 'should still be able to generate assets' do
+      stub_system_with 'public/assets', true
+      subject.should_not_receive(:`)
+      Guard::Notifier.should_receive(:notify).with('(Install tree for additional information)', :title => 'Assets compiled')
       subject.compile_assets
     end
   end


### PR DESCRIPTION
This approach does the following
- add an `:assets_prefix` configuration option that sets the assets directory (within `public/`). This will need to be kept in sync with the setting in `config/application.rb` or `config/environments/[env].rb`.
- use the `:assets_prefix` option for generation, cleanup, and as an argument to `tree` to get the status
- check whether `tree` is available on the system and, if not, print a less informative error message

This is mutually exclusive with https://github.com/guard/guard-rails-assets/pull/1
